### PR TITLE
correct typo in hacknet nodes section

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
         <div id="hacknet-nodes-money-multipliers-div">
             <p id="hacknet-nodes-money">
                 <span>Money:</span><span id="hacknet-nodes-player-money"></span><br/>
-                <span>Total Hacknet Node Prodution:</span><span id="hacknet-nodes-total-production"></span>
+                <span>Total Hacknet Node Production:</span><span id="hacknet-nodes-total-production"></span>
             </p>
             <span id="hacknet-nodes-multipliers">
                 <a id="hacknet-nodes-1x-multiplier" class="a-link-button-inactive"> x1 </a>


### PR DESCRIPTION
Where it shows the total hacknet node money generation per second, the page shows:
`Total Hacknet Node Prodution:`
This has been corrected to show:
`Total Hacknet Node Production:`